### PR TITLE
webserver update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,12 @@ SERVICE_FILE = config/cobweb.service
 .PHONY: all clean install uninstall run
 
 # Default target
-all: check-root $(COBOL_EXEC)
+all: $(COBOL_EXEC)
 
-# Ensure the script is run as root
+# Ensure the target is run as root
 check-root:
-	@if [ "$$(id -u)" -ne 0 ]; then echo "This script must be run as root"; exit 1; fi
+	@if [ "$$(id -u)" -ne 0 ]; then echo "This target can only be executed as root"; exit 1; fi
+
 # Create build directory if it doesn't exist
 build:
 	@mkdir -p build
@@ -25,7 +26,7 @@ $(COBOL_EXEC): build $(COBOL_SRC)
 	cobc -x -o $(COBOL_EXEC) $(COBOL_SRC)
 
 # Install the binary, config file, and systemd service
-install: $(COBOL_EXEC)
+install: check-root $(COBOL_EXEC)
 	@echo "Installing cobweb server..."
 	install -d $(INSTALL_PATH)
 	install -m 755 $(COBOL_EXEC) $(INSTALL_PATH)
@@ -33,7 +34,7 @@ install: $(COBOL_EXEC)
 	install -m 644 $(CONFIG_FILE) $(CONFIG_DIR)
 
 # Run the systemd service
-run: install
+run: check-root install
 	install -m 644 $(SERVICE_FILE) $(SYSTEMD_DIR)
 	@echo "Starting cobweb server..."
 	systemctl daemon-reload
@@ -41,7 +42,7 @@ run: install
 	systemctl start cobweb
 
 # Uninstall the binary, config file, and systemd service
-uninstall:
+uninstall: check-root
 	@echo "Uninstalling cobweb server..."
 	systemctl stop cobweb
 	systemctl disable cobweb

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Honestly, I did it on a dare. CobWeb is a simple webserver, written in COBOL, th
 
 The program does not have any explicit purpose other than to prove that such program, a webserver written in COBOL exists.
 
-The webserver, build, makefile was tested only on Debian 12 (bookworm) and GNUCobol 3.1.2.0
+The webserver, build, makefile was tested only on Debian 12 (bookworm) and GnuCOBOL 3.1.2.0
 
 The minimal configuration file for the server can be edited under /etc/cobweb/cobweb.conf
 
 ## What You Need
 
-- GNUCobol
+- GnuCOBOL
 - make utility
 - systemd (optional, but the Makefile assumes that you run systemd)
 
@@ -31,7 +31,7 @@ The binary will be in the build directory.
 
 ### Install It
 
-Run this to install the web server:
+Run this to install the web server (root rights needed):
 
 ```sh
 sudo make install
@@ -44,7 +44,7 @@ This will:
 
 ### Uninstall It
 
-Run this to uninstall the web server:
+Run this to uninstall the web server and its systemd service (root rights needed):
 
 ```sh
 sudo make uninstall
@@ -60,6 +60,8 @@ This will:
 
 
 ### Systemd service
+
+Install (if needed) and run the server (root rights needed):
 
 
 ```sh
@@ -80,11 +82,13 @@ make clean
 
 ## Configuration
 
-The config file is in `config/cobweb.conf`. Feel free to tweak it to suit your needs.
+The config file is in `config/cobweb.conf`. Feel free to tweak it to suit your needs. It includes the port number to bind to. 
+You may run the webserver binary locally by setting `COBWEB_CONFIG` to a different file.
 
 ## Systemd Service
 
-The service file is in `config/cobweb.service`. This file tells systemd how to manage your web server.
+The service file is in `config/cobweb.service`. This file tells systemd how to manage your web server.  
+**Warning:** the default is for the webserver to run as root, which should only be done on test system. You may create a new user and assign it in the service configuration. 
 
 ## Why COBOL?
 


### PR DESCRIPTION
* only require root for install and service-related parts
* warn about root in README
* allow overriding the config file, which allows to execute the non-installed binary (and a temporary override)
* use COMP for network byte order instead of calling htons